### PR TITLE
More updates for triclinic energy_std

### DIFF
--- a/lib/elastic_const.f90
+++ b/lib/elastic_const.f90
@@ -1888,7 +1888,7 @@ SELECT CASE (laue)
       press=- alpha(2) / omega
       WRITE(stdout,'("-(S12+S23)",f15.8," kbar",f15.8," kbar")') &
                                           press*ry_kbar, -(s12+s23)*ry_kbar
-      el_con(5,6) = (1.0_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(5,5) &
+      el_con(5,6) = (0.25_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(5,5) &
                                                - el_con(6,6)) *0.5_DP
       el_con(6,5) = el_con(5,6)
 !
@@ -1901,7 +1901,7 @@ SELECT CASE (laue)
       press=- alpha(2) / omega
       WRITE(stdout,'("-(S23+S12)",f15.8," kbar",f15.8," kbar")') &
                                           press*ry_kbar, -(s23+s12)*ry_kbar
-      el_con(4,6) = (1.0_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(4,4) &
+      el_con(4,6) = (0.25_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(4,4) &
                                                - el_con(6,6)) *0.5_DP
       el_con(6,4) = el_con(4,6)
 !
@@ -1914,7 +1914,7 @@ SELECT CASE (laue)
       press=- alpha(2) / omega
       WRITE(stdout,'("-(S13+S23)",f15.8," kbar",f15.8," kbar")') &
                                           press*ry_kbar, -(s13+s23)*ry_kbar
-      el_con(4,5) = (1.0_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(4,4) &
+      el_con(4,5) = (0.25_DP / omega * ( 2.0_DP * alpha(3) ) - el_con(4,4) &
                                                - el_con(5,5) ) * 0.5_DP
       el_con(5,4) = el_con(4,5)
 

--- a/lib/elastic_const.f90
+++ b/lib/elastic_const.f90
@@ -1856,7 +1856,7 @@ SELECT CASE (laue)
 !  C_35
 !
       base_data = 16*ngeo_strain+1
-      CALL el_cons_ij_ene(1, 1, 'C_35', ngeo_strain, &
+      CALL el_cons_ij_ene(3, 3, 'C_35', ngeo_strain, &
              epsil_geo(1,1,base_data), energy_geo(base_data), alpha, m1)
 
       press=- alpha(2) / omega
@@ -1869,7 +1869,7 @@ SELECT CASE (laue)
 !  C_34
 !
       base_data = 17*ngeo_strain+1
-      CALL el_cons_ij_ene(1, 1, 'C_34', ngeo_strain, &
+      CALL el_cons_ij_ene(3, 3, 'C_34', ngeo_strain, &
              epsil_geo(1,1,base_data), energy_geo(base_data), alpha, m1)
 
       press=- alpha(2) / omega

--- a/lib/strain.f90
+++ b/lib/strain.f90
@@ -192,14 +192,14 @@ ELSEIF (strain_code=='EI') THEN
    epsilon_voigt(3) = epsil
    epsilon_voigt(4) = epsil
 ELSEIF (strain_code=='GH') THEN
-   epsilon_voigt(4) = epsil
    epsilon_voigt(5) = epsil
+   epsilon_voigt(6) = epsil
 ELSEIF (strain_code=='GI') THEN
    epsilon_voigt(4) = epsil
    epsilon_voigt(6) = epsil
 ELSEIF (strain_code=='IH') THEN
+   epsilon_voigt(4) = epsil
    epsilon_voigt(5) = epsil
-   epsilon_voigt(6) = epsil
 ELSE
    WRITE(stdout,'(a2)') strain_code 
    CALL errore('set_strain','strain not programmed',1)

--- a/src/initialize_elastic_cons.f90
+++ b/src/initialize_elastic_cons.f90
@@ -306,8 +306,8 @@ SELECT CASE (laue)
             strain_list(17) = 'EH'
             strain_list(18) = 'EI'
             strain_list(19) = 'GH'
-            strain_list(20) = 'IH'
-            strain_list(21) = 'GI'
+            strain_list(20) = 'GI'
+            strain_list(21) = 'IH'
          END IF
       ELSE
          CALL errore('initialize_elastic_cons',&


### PR DESCRIPTION
Hi,

it's been a while, but I have now tested this quite a lot and am reasonably sure that the things I was not sure about in #12 are resolved. This PR fixes 3 issues with strains for triclinic cells by aligning code with the logic laid out in the documentation (thermo.tex, section 8.0.5):

- For C34 and C35 (strains EI and EH), the strain value is in e33
- strains GH,GI and IH are supposed to be 5+6, 4+6, 4+5 respectively (that also means one change from #12 was in fact wrong)
- For C45/46/56 (eqs. 8.178-180), the code was missing division of the volume by 2 from the equation and an additional division by 2 because for those strains we can't recover epsilon, we recover 2epsilon from the stored strain tensor (no diagonal element available).

The results I now get are for some test cells are reasonably close to those using the stresses directly.